### PR TITLE
Update process_keys.c

### DIFF
--- a/security/keys/process_keys.c
+++ b/security/keys/process_keys.c
@@ -792,6 +792,7 @@ long join_session_keyring(const char *name)
 		ret = PTR_ERR(keyring);
 		goto error2;
 	} else if (keyring == new->session_keyring) {
+		key_put(keyring);
 		ret = 0;
 		goto error2;
 	}


### PR DESCRIPTION
fix for the CVE-2016-0728
see: http://www.cve.mitre.org/cgi-bin/cvename.cgi?name=2016-0728
see: https://github.com/torvalds/linux/commit/23567fd052a9abb6d67fe8e7a9ccdd9800a540f2
