### PR TITLE
Adapted hdmi_edid.c to also scan for 4K output.

### DIFF
--- a/drivers/video/sunxi/disp2/hdmi/hdmi_edid.c
+++ b/drivers/video/sunxi/disp2/hdmi/hdmi_edid.c
@@ -163,9 +163,20 @@ static s32 edid_parse_dtd_block(u8 *pbuf)
 			Device_Support_VIC[HDMI1080P_50] = 1;
 		}
 	}
+	else if ((frame_rate == 30)) {
+		if ((sizex == 3840) && (sizey == 2840)) {
+			Device_Support_VIC[HDMI3840_2160P_30] = 1;
+		}
+	}
 	else if ((frame_rate == 23) || (frame_rate == 24)) {
 		if ((sizex== 1920) && (sizey == 1080)) {
 			Device_Support_VIC[HDMI1080P_24] = 1;
+		}
+		if ((sizex == 3840) && (sizey == 2840) && frame_rate == 24) {
+			Device_Support_VIC[HDMI3840_2160P_24] = 1;
+		}
+		if ((sizex == 3840) && (sizey == 2840) && frame_rate == 25) {
+			Device_Support_VIC[HDMI3840_2160P_25] = 1;
 		}
 	}
 	__inf("PCLK=%d\tXsize=%d\tYsize=%d\tFrame_rate=%d\n",


### PR DESCRIPTION
Hi,

Due to lack of time from my side I'm posting this branch here. The code should compile. However I'm not sure if this is already sufficient to run on 4K displays. This is mainly due to technical reasons: So far I was unable to put the kernel onto the device and test the code with our TV. I use OSX as my main OS and haven't used Archlinux before so I'll need to read into it first before I can do any testing. I used Gentoo a couple years ago so that should be no problem. 

Now to the 4K output problem: Looking at the code it seems that 4K support is already built in. However, there's no 4K hardware detection that triggers the respective 4K routines. This Pull Request tries solve this issue. 

Feel free to test. Note: I'm not liable for broken TVs.

4K support in the Allwinner drivers:
- https://github.com/allwinner-zh/bootloader/blob/e5ceeca211883d9f6b25f84e0e3c5fe2afaaf350/u-boot-2011.09/drivers/video_sunxi/sunxi_v3/hdmi/drv_hdmi.c#L125
- https://github.com/allwinner-zh/bootloader/blob/e5ceeca211883d9f6b25f84e0e3c5fe2afaaf350/u-boot-2011.09/drivers/video_sunxi/sunxi_v3/de/disp_display.c#L481

Kernel 4K support:
- https://github.com/longsleep/linux-pine64/blob/b44d032aa4090136c2f17c53ed0707064ce2c6da/drivers/video/sunxi/disp2/hdmi/hdmi_core.c#L45
- https://github.com/longsleep/linux-pine64/blob/b44d032aa4090136c2f17c53ed0707064ce2c6da/include/video/sunxi_display2.h#L153
- https://github.com/longsleep/linux-pine64/blob/b44d032aa4090136c2f17c53ed0707064ce2c6da/drivers/video/sunxi/disp2/hdmi/hdmi_core.c#L325

Audio should also be an easy fix if we know the sample rate: https://github.com/longsleep/linux-pine64/blob/b44d032aa4090136c2f17c53ed0707064ce2c6da/drivers/video/sunxi/disp2/hdmi/hdmi_core.c#L264 (it's probably sufficient to copy the 1080p line).
