### PR TITLE
remove mmc_do_erase debug message from dmesg

### DIFF
--- a/drivers/mmc/core/core.c
+++ b/drivers/mmc/core/core.c
@@ -1897,9 +1897,10 @@ static int mmc_do_erase(struct mmc_card *card, unsigned int from,
 		from <<= 9;
 		to <<= 9;
 	}
-
+#ifdef CONFIG_MMC_DEBUG
 	pr_info("%s:%s: erase from %d to %d arg 0x%08x\n",
 		mmc_hostname(card->host), __func__, from, to, arg);
+#endif
 	if (mmc_card_sd(card))
 		cmd.opcode = SD_ERASE_WR_BLK_START;
 	else


### PR DESCRIPTION
remove mmc_do_erase debug message from dmesg
