### PR TITLE
Revert "random32: add prandom_u32_max and convert open coded users"

### DIFF
--- a/include/linux/random.h
+++ b/include/linux/random.h
@@ -33,23 +33,6 @@ void prandom_seed(u32 seed);
 u32 prandom_u32_state(struct rnd_state *);
 void prandom_bytes_state(struct rnd_state *state, void *buf, int nbytes);
 
-/**
- * prandom_u32_max - returns a pseudo-random number in interval [0, ep_ro)
- * @ep_ro: right open interval endpoint
- *
- * Returns a pseudo-random number that is in interval [0, ep_ro). Note
- * that the result depends on PRNG being well distributed in [0, ~0U]
- * u32 space. Here we use maximally equidistributed combined Tausworthe
- * generator, that is, prandom_u32(). This is useful when requesting a
- * random index of an array containing ep_ro elements, for example.
- *
- * Returns: pseudo-random number in interval [0, ep_ro)
- */
-static inline u32 prandom_u32_max(u32 ep_ro)
-{
-	return (u32)(((u64) prandom_u32() * ep_ro) >> 32);
-}
-
 /*
  * Handle minimum values for seeds
  */


### PR DESCRIPTION
I'm not sure what the deal is with all the various branches you have, but I'd appreciate it if in addition to merging this in whatever random branch I've selected for this PR, you could also cherry-pick it into all the other branches folks are using.

---------------

This reverts commit a6cdc1c6420f274eae456252d700b24e8d1edc1c.

Linux 3.10 does not have this function, because nothing in Linux 3.10
uses it. It was never backported in any of the kernel.org stable trees
to 3.10. Its current inclusion in this pine64 kernel here adds nothing.

The reason this is a problem is because wireguard's compat layer assumes
that 3.10 kernels won't have this function, so having it here actually
causes problems. Sure, we could work around this in wireguard, but it
doesn't seem prudent to play the game of accounting for every possible
frankenkernel out there.

Instead this commit simply reverts the faulty backport.

Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>